### PR TITLE
fix: exclude autoref tags from anchor tag processing

### DIFF
--- a/src/mkdocs_backlinks_section_plugin/__init__.py
+++ b/src/mkdocs_backlinks_section_plugin/__init__.py
@@ -19,8 +19,8 @@ from mkdocs.structure.pages import Page
 
 # Marks URLs that should be ignored
 BAD_URL_STARTS = ["http://", "https://", "tel:", "#"]
-# Regular expression for anchor tags
-LINK_START_TAG_REGEX = re.compile(r"<a[^>]*>", re.MULTILINE)
+# Regular expression for anchor tags (excludes autoref tags)
+LINK_START_TAG_REGEX = re.compile(r"<a(?:\s[^>]*)?>", re.MULTILINE)
 HREF_DOUBLE_QUOTED_REGEX = re.compile(r'\shref="([^"]*)"')
 HREF_SINGLE_QUOTED_REGEX = re.compile(r"\shref='([^']*)'")
 HREF_UNQUOTED_REGEX = re.compile(r"\shref=([^\s>]*)")


### PR DESCRIPTION
Fixes compatibility issue with mkdocstrings where `<autoref>` tags were being processed as regular anchor tags, causing warnings about missing href attributes.

## Problem
The plugin generates spam warnings when used with mkdocstrings because it tries to parse `<autoref>` tags (from mkdocstrings) as regular anchor tags. Since `<autoref>` tags don't have href attributes, this causes warnings like:

```
WARNING - mkdocs_backlinks_section_plugin: On page 'reference/tux/core/logging.md' an anchor tag has no href: <autoref identifier="str" backlink-type="used-by" backlink-anchor="tux.core.logging.StructuredLogger.performance" optional>
```

## Solution
Modified the `LINK_START_TAG_REGEX` to specifically match `<a>` tags while excluding `<autoref>` tags:
- Changed from: `r"<a[^>]*>"`
- Changed to: `r"<a(?:\s[^>]*)?>"`

## Testing
- Validated against all existing anchor tag variations in the docs
- Confirmed `<autoref>` tags are properly excluded
- No regressions in existing functionality
- Maintains backward compatibility with all regular anchor tags

## Impact
- Eliminates false positive warnings for mkdocstrings users
- No functional changes for users not using mkdocstrings
- Minimal, targeted fix with no breaking changes